### PR TITLE
Fixing creation of plugin object and dependencies list

### DIFF
--- a/js/boot.js
+++ b/js/boot.js
@@ -97,6 +97,13 @@ var boot = {
 
     var exec = require('child_process').exec;
 
+    // create the plugin object if it doesn't exist yet
+    if (!window.lunchbox_drupalvm_plugin) {
+      window.lunchbox_drupalvm_plugin = { dependencies: [] };
+    } else {
+      window.lunchbox_drupalvm_plugin.dependencies = [];
+    }
+
     software.forEach(function (item) {
       chain.then(function () {
         var deferred = Q.defer();
@@ -168,21 +175,11 @@ var boot = {
         });
 
         deferred.promise.then(function(data) {
-          // create the plugin object if it doesn't exist yet
-          if (!window.lunchbox_drupalvm_plugin) {
-            window.lunchbox_drupalvm_plugin = { dependencies: [] };
-          }
-
           // add the dependency object to the array
           window.lunchbox_drupalvm_plugin.dependencies.push(item);
         },
 
         function(err) {
-          // create the plugin object if it doesn't exist yet
-          if (!window.lunchbox_drupalvm_plugin) {
-            window.lunchbox_drupalvm_plugin = { dependencies: [] };
-          }
-
           // add the error to the dependency object and
           // add the dependency object to the array
           item.error = err;


### PR DESCRIPTION
- Moved creation of plugin object and dependencies list to outside of
the software chain
- If the plugin was loaded multiple times, the same dependencies were
added to the already existing list again. This way, the list is
recreated each time the plugin is loaded