### PR TITLE
Fix variable in `provision()` to use the correct state name

### DIFF
--- a/main.js
+++ b/main.js
@@ -676,11 +676,11 @@ DrupalVM.prototype.stop = function () {
 DrupalVM.prototype.provision = function () {
   var self = this;
 
-  if (this.state & this._NEEDS_REPROVISION) {
+  if (this.state & this._NEEDS_PROVISION) {
     this.control(this.CONTROL_PROVISION).then(function () {
       console.log('finished provisioning');
 
-      self.state -= self._NEEDS_REPROVISION;
+      self.state -= self._NEEDS_PROVISION;
       self.stateChange();
 
       self.hideProvisionNotice();


### PR DESCRIPTION
- The function is using `_NEEDS_REPROVISION`, but the state is named
`_NEEDS_PROVISION`, so this check will always fail making provisioning
impossible